### PR TITLE
Add Github Annotation Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Display each filename & pass/fail status, along with compact results:
 | Flag | Description
 |---|---|
 |`--compact` or `-c` | Minimal output.  Display each result on a single line. |
+|`--github` or `-g` | GitHub Annotation output.  Use `error` command to create annotation. Useful when you are running x-ray within GitHub Actions. |
 |`--ignore` or `-i` | Ignore a file or path, can be specified multiple times. Accepts glob patterns. |
 |`--no-progress` or `-P` | Don't display the progress bar while scanning files |
 |`--snippets` or `-S` | Display code snippets from located calls |

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -40,6 +40,7 @@ class ScanCommand extends Command
             ->addOption('snippets', 'S', InputOption::VALUE_NONE, 'Display highlighted code snippets')
             ->addOption('summary', 's', InputOption::VALUE_NONE, 'Display a table summarizing the results')
             ->addOption('compact', 'c', InputOption::VALUE_NONE, 'Display results in a compact format')
+            ->addOption('github', 'g', InputOption::VALUE_NONE, 'Display results in a github annotation format')
             ->addOption('ignore', 'i',  InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore one or more files/paths')
             ->setDescription('Scans a directory or filename for calls to ray(), rd() and Ray::*.');
     }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -16,6 +16,7 @@ class Configuration
         public bool $showSnippets,
         public bool $hideProgress,
         public bool $showSummary,
+        public bool $githubAnnotation = false,
         public bool $compactMode = false,
         public bool $verboseMode = false,
     ) {

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -20,11 +20,12 @@ class ConfigurationFactory
         $hideProgress = self::getOption($input, 'no-progress', false);
         $showSnippets = self::getOption($input, 'snippets', false);
         $showSummary = self::getOption($input, 'summary', false);
+        $githubAnnotation = self::getOption($input, 'github', false);
         $compactMode = self::getOption($input, 'compact', false);
         $verboseMode = self::getOption($input, 'verbose', false);
         $ignorePaths = self::getOption($input, 'ignore', []);
 
-        $result = new Configuration($paths, $showSnippets, $hideProgress, $showSummary, $compactMode, $verboseMode);
+        $result = new Configuration($paths, $showSnippets, $hideProgress, $showSummary, $githubAnnotation, $compactMode, $verboseMode);
         $options = (new static())->getSettingsFromConfigFile($configDirectory);
 
         $result->loadOptionsFromConfigurationFile($options, $ignorePaths);

--- a/src/Printers/ConsoleResultsPrinter.php
+++ b/src/Printers/ConsoleResultsPrinter.php
@@ -56,6 +56,10 @@ class ConsoleResultsPrinter extends ResultsPrinter
         $filesWord = $totalFiles === 1 ? 'file' : 'files';
 
         MessagePrinter::warning($this->output, "Found {$totalCalls} {$callsWord} in {$totalFiles} {$filesWord}.");
+
+        if ($this->config->githubAnnotation) {
+            $this->printGithubAnnotationLines($results);
+        }
     }
 
     protected function summarizeCalls(array $results): array
@@ -104,6 +108,21 @@ class ConsoleResultsPrinter extends ResultsPrinter
             ->setRows($rows);
 
         $table->render();
+    }
+
+    protected function printGithubAnnotationLines(array $results)
+    {
+        /** @var FileSearchResults $scanResult */
+        foreach ($results as $scanResult) {
+            foreach ($scanResult->results as $result) {
+                $this->output->writeln(sprintf(
+                    "::error file=%s,line=%d,col=%d::Found a ray call",
+                    str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $result->file()->filename),
+                    $result->location->startLine(),
+                    $result->location->column(),
+                ));
+            }
+        }
     }
 
     protected function makeFilenameRelative(string $filename): string

--- a/tests/Printers/ConsoleResultsPrinterTest.php
+++ b/tests/Printers/ConsoleResultsPrinterTest.php
@@ -46,4 +46,20 @@ class ConsoleResultsPrinterTest extends TestCase
 
         $this->assertMatchesSnapshot($output->writtenData);
     }
+
+    /** @test */
+    public function it_prints_a_summary_with_github_annotation()
+    {
+        $path = __DIR__ . '/../fixtures/fixture1.php';
+        $config = $this->createConfiguration([$path], null, ['path' => $path, '--github' => true]);
+        $output = new FakeOutput();
+        $printer = new ConsoleResultsPrinter($output, $config);
+        $printer->consoleColor = new FakeConsoleColor();
+        $scanner = new CodeScanner($config, $path);
+
+        $results = $scanner->scan();
+        $printer->printSummary($results);
+
+        $this->assertMatchesSnapshot($output->writtenData);
+    }
 }

--- a/tests/Printers/__snapshots__/ConsoleResultsPrinterTest__it_prints_a_summary_with_github_annotation__1.yml
+++ b/tests/Printers/__snapshots__/ConsoleResultsPrinterTest__it_prints_a_summary_with_github_annotation__1.yml
@@ -1,0 +1,2 @@
+- ' <fg=#ef4444>❗</>Found 1 call in 1 file.'
+- '::error file=tests/fixtures/fixture1.php,line=2,col=0::Found a ray call'

--- a/tests/Traits/CreatesTestConfiguration.php
+++ b/tests/Traits/CreatesTestConfiguration.php
@@ -19,6 +19,7 @@ trait CreatesTestConfiguration
             new InputOption('no-progress', 'P', InputOption::VALUE_NONE),
             new InputOption('snippets', 'S', InputOption::VALUE_NONE),
             new InputOption('summary', 's', InputOption::VALUE_NONE),
+            new InputOption('github', 'g', InputOption::VALUE_NONE),
             new InputOption('verbose', 'v', InputOption::VALUE_NONE),
         ]);
 


### PR DESCRIPTION
We can use GitHub's workflow command to make annotations.
This is a POC that appends such commands.


Annotation will be display on GitHub like this:
https://github.com/binotaliu/x-ray-annotation-demo/commit/c280f8b717313eb78cf8e0b6bfc63db770d0d103#diff-0524b271e915e8060f768ae50abd7ea860fa5ec3b9d842218c2c207347d77f1d

<img width="468" alt="CleanShot 2021-10-04 at 01 29 35@2x" src="https://user-images.githubusercontent.com/67255597/135764918-7f6abc71-8661-4a8f-927e-1169cb0c5de0.png">
