### PR TITLE
Update typehint for Symfony 6 support

### DIFF
--- a/tests/TestClasses/FakeOutput.php
+++ b/tests/TestClasses/FakeOutput.php
@@ -21,7 +21,7 @@ class FakeOutput implements OutputInterface
         return $this->formatter;
     }
 
-    public function getVerbosity()
+    public function getVerbosity(): int
     {
         // TODO: Implement getVerbosity() method.
     }

--- a/tests/TestClasses/FakeOutput.php
+++ b/tests/TestClasses/FakeOutput.php
@@ -24,6 +24,7 @@ class FakeOutput implements OutputInterface
     public function getVerbosity(): int
     {
         // TODO: Implement getVerbosity() method.
+        return 0;
     }
 
     public function isDebug()


### PR DESCRIPTION
This PR adds typehints to the `FakeOutput` class to allow support for Symfony v6.