### PR TITLE
Add "clean" command

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,14 +18,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Auto-merge Dependabot PRs for semver-minor updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Auto-merge Dependabot PRs for semver-patch updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/run-phpstan.yml
+++ b/.github/workflows/run-phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2, 8.1, 8.0]
+        php: [8.3, 8.2]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 This package can quickly scan source code for calls to `ray()`, `rd()`, `Ray::*`, and `->ray()` helper methods from the [spatie/ray](https://github.com/spatie/ray) and [spatie/laravel-ray](https://github.com/spatie/laravel-ray) packages.
 
-The primary use case is when calls to `ray()` cannot be left in source code before deploying, even if ray is disabled.  This package does NOT remove the calls, it simply displays their locations so they can be removed manually.
+The primary use case is when calls to `ray()` cannot be left in source code before deploying, even if ray is disabled.  This package can also remove the calls, via the `clean` command.
 
 The exit code of the `x-ray` command is zero if no ray calls are found, and non-zero if calls are found.  This allows the package to be used in an automated environment such as Github Workflows.
 
@@ -83,6 +83,20 @@ paths:
     - 'SettingsTest.php'
 ```
 
+## Removing calls
+
+The `clean` command will remove all calls to `ray()`, `rd()`, `Ray::*` and chained '->ray()' methods from the specified files or paths.
+
+```bash
+./vendor/bin/x-ray clean ./app/Actions/MyAction.php ./app/Models/*.php ./tests
+```
+
+Perform a dry run first:
+
+```bash
+./vendor/bin/x-ray clean ./app/Actions/MyAction.php ./app/Models/*.php ./tests --dry-run
+```
+
 ## Automation
 
 `x-ray` was designed to be used not only as a manual utility, but in conjunction with automation tools.  
@@ -109,13 +123,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.0, 7.4]
+        php: [8.3, 8.2]
 
     name: P${{ matrix.php }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -136,7 +150,7 @@ jobs:
         run: ./vendor/bin/phpunit
         
       - name: Check for ray calls
-        run: ./vendor/bin/x-ray . --compact
+        run: ./vendor/bin/x-ray . --github
 ```
 
 ## Git hooks
@@ -168,12 +182,11 @@ You can also use `x-ray` with husky in your `package.json` configuration:
 ...
 "husky": {
     "hooks": {
-        "pre-commit": "lint-staged && .x-ray -s ."
+        "pre-commit": "lint-staged && php ./vendor/bin/x-ray -s ."
     }
 },
 ....
 ```
-
 
 ## Screenshots
 

--- a/bin/x-ray
+++ b/bin/x-ray
@@ -13,8 +13,20 @@ use Spatie\XRay\Commands\ScanCommand;
 use Symfony\Component\Console\Application;
 
 $application = new Application('x-ray', '1.0.0');
-$command = new ScanCommand();
+$scanCommandName = 'x-ray';
 
-$application->add($command);
-$application->setDefaultCommand($command->getName(), true);
+if ($argv[1] === 'scan') {
+    $scanCommandName = 'scan';
+}
+
+$scanCommand = new ScanCommand($scanCommandName);
+$cleanCommand = new \Spatie\XRay\Commands\CleanCommand();
+
+$application->add($scanCommand);
+$application->add($cleanCommand);
+
+if (! in_array($argv[1], ['clean', 'scan'])) {
+    $application->setDefaultCommand($scanCommand->getName(), true);
+}
+
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,10 @@
         "symfony/yaml": "^5.3|^6.0|^7.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12.92",
-        "phpunit/phpunit": "^9.5",
-        "spatie/phpunit-snapshot-assertions": "^4.2"
+        "phpstan/phpstan": "^1.10.56",
+        "phpunit/phpunit": "^10.0.0",
+        "rector/rector": "^1.0.0",
+        "spatie/phpunit-snapshot-assertions": "^5.1.4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "spatie/x-ray",
-    "description": "Quickly scan source code for calls to Ray",
+    "description": "Quickly find or remove calls to spatie/ray",
     "license": "MIT",
     "keywords": [
         "spatie",
@@ -28,12 +28,12 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "permafrost-dev/code-snippets": "^1.2.0",
         "permafrost-dev/php-code-search": "^1.10.5",
-        "symfony/console": "^5.3|^6.0|^7.0",
-        "symfony/finder": "^5.3|^6.0|^7.0",
-        "symfony/yaml": "^5.3|^6.0|^7.0"
+        "symfony/console": "^6.0|^7.0",
+        "symfony/finder": "^6.0|^7.0",
+        "symfony/yaml": "^6.0|^7.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10.56",

--- a/remove-ray-rector.php
+++ b/remove-ray-rector.php
@@ -1,0 +1,7 @@
+<?php
+
+use Spatie\XRay\Support\RemoveRayCallRector;
+
+return static function (\Rector\Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveRayCallRector::class);
+};

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\XRay\Commands;
+
+use InvalidArgumentException;
+use Spatie\XRay\CodeScanner;
+use Spatie\XRay\Configuration\Configuration;
+use Spatie\XRay\Configuration\ConfigurationFactory;
+use Spatie\XRay\Exceptions\MissingArgumentException;
+use Spatie\XRay\Printers\ConsoleResultsPrinter;
+use Spatie\XRay\Printers\MessagePrinter;
+use Spatie\XRay\Printers\ResultsPrinter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class CleanCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('clean')
+            ->addArgument('path', InputArgument::REQUIRED)
+            ->setDescription('Removes calls to ray(), ->ray(), rd() and Ray::*.');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $input->getArgument('path');
+        $code = 0;
+        passthru('php vendor/bin/rector process "'.$path.'" --dry-run --config ./remove-ray-rector.php', $code);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -36,9 +36,13 @@ class CleanCommand extends Command
         $path = $input->getArgument('path');
         $dryRun = $input->getOption('dry-run');
 
+        $configFn = file_exists('./remove-ray-rector.php')
+            ? './remove-ray-rector.php'
+            : './vendor/spatie/x-ray/remove-ray-rector.php';
+
         $flags = implode(' ', array_filter([
             $dryRun ? '--dry-run' : false,
-            '--config ./remove-ray-rector.php',
+            '--config '.$configFn,
         ]));
 
         passthru('php vendor/bin/rector process "'.$path.'" '.$flags.' >&2', $code);

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -34,7 +34,7 @@ class ScanCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName('x-ray')
+        $this->setName($this->getName())
             ->addArgument('path', InputArgument::IS_ARRAY)
             ->addOption('no-progress', 'P', InputOption::VALUE_NONE, 'Don\'t display the progress bar')
             ->addOption('snippets', 'S', InputOption::VALUE_NONE, 'Display highlighted code snippets')

--- a/src/Support/RemoveRayCallRector.php
+++ b/src/Support/RemoveRayCallRector.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Spatie\XRay\Support;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeTraverser;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class RemoveRayCallRector extends AbstractRector
+{
+    public function getRuleDefinition(): \Symplify\RuleDocGenerator\ValueObject\RuleDefinition
+    {
+        return new RuleDefinition('Remove Ray calls', [new ConfiguredCodeSample(<<<'CODE_SAMPLE'
+$x = 'something';
+ray($x);
+CODE_SAMPLE
+            , <<<'CODE_SAMPLE'
+$x = 'something';
+CODE_SAMPLE
+            , ['ray'])]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Expression::class];
+    }
+
+    public function refactor(Node $node): ?int
+    {
+        $expr = $node->expr;
+
+        if (! $expr instanceof FuncCall && ! $expr instanceof MethodCall && ! $expr instanceof StaticCall) {
+            return null;
+        }
+
+        if ($expr instanceof Node\Expr\StaticCall && str_ends_with($expr->class, 'Spatie\\Ray\\Ray')) {
+            return NodeTraverser::REMOVE_NODE;
+        }
+
+        if ($this->isName($expr->name, 'ray')) {
+            return NodeTraverser::REMOVE_NODE;
+        }
+
+        if ($this->isName($expr->name, 'rd') && $expr instanceof FuncCall) {
+            return NodeTraverser::REMOVE_NODE;
+        }
+
+        if ($expr->var->name->parts && in_array('ray', $expr->var->name->parts)) {
+            return NodeTraverser::REMOVE_NODE;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This PR borrows and extends code from `spatie/ray` to implement a `rector/rector` rule for removing calls to `ray()`, `rd()`, `Ray::*` and `->ray()`.

It adds a `clean` subcommand to the `x-ray` command:

```bash
x-ray clean <path> [--dry-run]
```

The `clean` command uses rector to remove references to the functions/methods listed above.  In the original `spatie/ray` code, some of the possible functions/methods weren't accounted for; this PR updates the code to account for all possible `ray` references.

This PR also bumps several dependency versions, drops support for PHP versions below 8.1 and drops `symfony/*` support for versions below `6.x`. As such, a new major version release is likely best for releasing the functionality in this PR. 

---

The ultimate objective for this PR is to remove the related functionality from `spatie/ray` to keep concerns separate; I believe that this functionality belongs in the `spatie/x-ray` package **instead of** the `spatie/ray` package.  The `ray` package should only contain functionality related to `Ray`, in our opinion.

ping @freekmurze - any thoughts on this?