### PR TITLE
Fix Symfony Console v8 compatibility

### DIFF
--- a/bin/x-ray
+++ b/bin/x-ray
@@ -15,6 +15,10 @@ use Symfony\Component\Console\Application;
 $application = new Application('x-ray', '1.0.0');
 $command = new ScanCommand();
 
-$application->add($command);
+if (method_exists($application, 'addCommand')) {
+    $application->addCommand($command);
+} else {
+    $application->add($command);
+}
 $application->setDefaultCommand($command->getName(), true);
 $application->run();

--- a/tests/TestClasses/FakeOutput.php
+++ b/tests/TestClasses/FakeOutput.php
@@ -41,7 +41,11 @@ class FakeOutput implements OutputInterface
 
     public function isQuiet(): bool
     {
-        // TODO: Implement isQuiet() method.
+        return false;
+    }
+
+    public function isSilent(): bool
+    {
         return false;
     }
 


### PR DESCRIPTION
## Summary
- `Application::add()` was removed in Symfony Console v8, causing a fatal error (`Call to undefined method`) when x-ray is installed alongside Symfony 8 dependencies
- Uses `method_exists()` to call `addCommand()` (v8+) or `add()` (v5-v7), maintaining backward compatibility
- Adds the `isSilent()` method to the test `FakeOutput` class to satisfy the updated `OutputInterface` in v8

Fixes #69

## Test plan
- [x] Verified `bin/x-ray --help` works with Symfony Console v8
- [x] All 25 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)