### PR TITLE
Fix code style with Laravel Pint

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,5 @@
+{
+    "exclude": [
+        "tests/fixtures"
+    ]
+}

--- a/src/CodeScanner.php
+++ b/src/CodeScanner.php
@@ -11,7 +11,7 @@ class CodeScanner
 {
     protected array $paths;
 
-    public function __construct(protected Configuration $config, string | array $path)
+    public function __construct(protected Configuration $config, string|array $path)
     {
         if (! is_array($path)) {
             $path = [$path];
@@ -22,7 +22,7 @@ class CodeScanner
 
     public function scanFile(string $file): FileSearchResults
     {
-        $searcher = new Searcher();
+        $searcher = new Searcher;
 
         return $searcher
             ->functions($this->config->functions->values())
@@ -115,7 +115,7 @@ class CodeScanner
 
         foreach ($pathMap as $result => $paths) {
             if (in_array($path, $paths, true) || in_array(basename($path), $paths, true)) {
-                return (bool)$result;
+                return (bool) $result;
             }
         }
 
@@ -123,43 +123,43 @@ class CodeScanner
             foreach ($paths as $pathname) {
                 $pathname = str_replace(['*', '?', '~'], ['.*', '.', '\\~'], $pathname);
 
-                if (preg_match('~' . $pathname . '~', $path) === 1) {
-                    return (bool)$result;
+                if (preg_match('~'.$pathname.'~', $path) === 1) {
+                    return (bool) $result;
                 }
             }
         }
 
-//        if (in_array($path, $this->config->pathnames->included(), true)) {
-//            return false;
-//        }
-//
-//        if (in_array(basename($path), $this->config->pathnames->included(), true)) {
-//            return false;
-//        }
-//
-//        if (in_array($path, $this->config->pathnames->ignored(), true)) {
-//            return true;
-//        }
-//
-//        if (in_array(basename($path), $this->config->pathnames->ignored(), true)) {
-//            return true;
-//        }
+        //        if (in_array($path, $this->config->pathnames->included(), true)) {
+        //            return false;
+        //        }
+        //
+        //        if (in_array(basename($path), $this->config->pathnames->included(), true)) {
+        //            return false;
+        //        }
+        //
+        //        if (in_array($path, $this->config->pathnames->ignored(), true)) {
+        //            return true;
+        //        }
+        //
+        //        if (in_array(basename($path), $this->config->pathnames->ignored(), true)) {
+        //            return true;
+        //        }
 
-//        foreach ($this->config->pathnames->included() as $pathname) {
-//            $pathname = str_replace(['*', '?', '~'], ['.*', '.', '\\~'], $pathname);
-//
-//            if (preg_match('~' . $pathname . '~', $path) === 1) {
-//                return false;
-//            }
-//        }
-//
-//        foreach ($this->config->pathnames->ignored() as $pathname) {
-//            $pathname = str_replace(['*', '?', '~'], ['.*', '.', '\\~'], $pathname);
-//
-//            if (preg_match('~' . $pathname . '~', $path) === 1) {
-//                return true;
-//            }
-//        }
+        //        foreach ($this->config->pathnames->included() as $pathname) {
+        //            $pathname = str_replace(['*', '?', '~'], ['.*', '.', '\\~'], $pathname);
+        //
+        //            if (preg_match('~' . $pathname . '~', $path) === 1) {
+        //                return false;
+        //            }
+        //        }
+        //
+        //        foreach ($this->config->pathnames->ignored() as $pathname) {
+        //            $pathname = str_replace(['*', '?', '~'], ['.*', '.', '\\~'], $pathname);
+        //
+        //            if (preg_match('~' . $pathname . '~', $path) === 1) {
+        //                return true;
+        //            }
+        //        }
 
         return false;
     }

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -41,7 +41,7 @@ class ScanCommand extends Command
             ->addOption('summary', 's', InputOption::VALUE_NONE, 'Display a table summarizing the results')
             ->addOption('compact', 'c', InputOption::VALUE_NONE, 'Display results in a compact format')
             ->addOption('github', 'g', InputOption::VALUE_NONE, 'Display results in a github annotation format')
-            ->addOption('ignore', 'i',  InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore one or more files/paths')
+            ->addOption('ignore', 'i', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore one or more files/paths')
             ->setDescription('Scans a directory or filename for calls to ray(), rd() and Ray::*.');
     }
 
@@ -53,7 +53,7 @@ class ScanCommand extends Command
                 ->scanPaths()
                 ->printResults();
         } catch (InvalidArgumentException $e) {
-            $output->writeln('<fg=yellow;options=bold>Error: </>' . $e->getMessage());
+            $output->writeln('<fg=yellow;options=bold>Error: </>'.$e->getMessage());
 
             return Command::FAILURE;
         } catch (MissingArgumentException $e) {
@@ -89,7 +89,7 @@ class ScanCommand extends Command
 
             if ($this->config->verboseMode) {
                 if ($results->hasErrors()) {
-                    MessagePrinter::error($this->output, $path . ' <fg=#DC2626>(syntax or parsing error)</>', '   ');
+                    MessagePrinter::error($this->output, $path.' <fg=#DC2626>(syntax or parsing error)</>', '   ');
 
                     return;
                 }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -27,7 +27,7 @@ class Configuration
         }
 
         $this->functions = ConfigurationItemList::make(['ray', 'rd']);
-        $this->pathnames = new ConfigurationItemList();
+        $this->pathnames = new ConfigurationItemList;
     }
 
     public function validate(): self
@@ -38,7 +38,7 @@ class Configuration
 
         foreach ($this->paths as $path) {
             if (! file_exists($path)) {
-                throw new InvalidArgumentException('Invalid input file or path provided: ' . $path);
+                throw new InvalidArgumentException('Invalid input file or path provided: '.$path);
             }
         }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -26,7 +26,7 @@ class ConfigurationFactory
         $ignorePaths = self::getOption($input, 'ignore', []);
 
         $result = new Configuration($paths, $showSnippets, $hideProgress, $showSummary, $githubAnnotation, $compactMode, $verboseMode);
-        $options = (new static())->getSettingsFromConfigFile($configDirectory);
+        $options = (new static)->getSettingsFromConfigFile($configDirectory);
 
         $result->loadOptionsFromConfigurationFile($options, $ignorePaths);
 
@@ -71,7 +71,7 @@ class ConfigurationFactory
             'x-ray.yml',
         ];
 
-        $configDirectory = $configDirectory ?? (string)getcwd();
+        $configDirectory = $configDirectory ?? (string) getcwd();
 
         while (@is_dir($configDirectory)) {
             foreach ($configNames as $configName) {

--- a/src/Configuration/ConfigurationItemList.php
+++ b/src/Configuration/ConfigurationItemList.php
@@ -14,7 +14,7 @@ class ConfigurationItemList
 
     public static function make(array $defaults, bool $isPartial = false): self
     {
-        $result = new self();
+        $result = new self;
         $result->isPartial = $isPartial;
         $result->default = $defaults;
 

--- a/src/Printers/ConsoleResultPrinter.php
+++ b/src/Printers/ConsoleResultPrinter.php
@@ -28,7 +28,7 @@ class ConsoleResultPrinter extends ResultPrinter
 
     protected function printResultLine(OutputInterface $output, SearchResult $result)
     {
-        $filename = str_replace(getcwd() . DIRECTORY_SEPARATOR, './', $result->file()->filename);
+        $filename = str_replace(getcwd().DIRECTORY_SEPARATOR, './', $result->file()->filename);
 
         if ($this->config->compactMode) {
             return $this->printCompactResultLine($output, $result);
@@ -39,13 +39,13 @@ class ConsoleResultPrinter extends ResultPrinter
         $output->writeln(" <fg=#78716C;options=bold>❱</> Found: <fg=#e53e3e>{$nodeName}</>");
         $output->writeln(" <fg=#78716C;options=bold>❱</> File : {$filename}:<options=bold>{$result->location->startLine()}</>");
 
-        //e53e3e
+        // e53e3e
         $output->writeln('');
     }
 
     protected function printCompactResultLine(OutputInterface $output, SearchResult $result)
     {
-        $filename = str_replace(getcwd() . DIRECTORY_SEPARATOR, './', $result->file()->filename);
+        $filename = str_replace(getcwd().DIRECTORY_SEPARATOR, './', $result->file()->filename);
 
         $output->writeln(" {$filename}:<fg=#52525B>{$result->location->startLine()}</>");
 

--- a/src/Printers/ConsoleResultsPrinter.php
+++ b/src/Printers/ConsoleResultsPrinter.php
@@ -116,8 +116,8 @@ class ConsoleResultsPrinter extends ResultsPrinter
         foreach ($results as $scanResult) {
             foreach ($scanResult->results as $result) {
                 $this->output->writeln(sprintf(
-                    "::error file=%s,line=%d,col=%d::Found a ray call",
-                    str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $result->file()->filename),
+                    '::error file=%s,line=%d,col=%d::Found a ray call',
+                    str_replace(getcwd().DIRECTORY_SEPARATOR, '', $result->file()->filename),
                     $result->location->startLine(),
                     $result->location->column(),
                 ));
@@ -127,6 +127,6 @@ class ConsoleResultsPrinter extends ResultsPrinter
 
     protected function makeFilenameRelative(string $filename): string
     {
-        return str_replace(getcwd() . DIRECTORY_SEPARATOR, './', $filename);
+        return str_replace(getcwd().DIRECTORY_SEPARATOR, './', $filename);
     }
 }

--- a/src/Printers/Highlighters/ConsoleColor.php
+++ b/src/Printers/Highlighters/ConsoleColor.php
@@ -4,11 +4,13 @@ namespace Spatie\XRay\Printers\Highlighters;
 
 /**
  * Original source from nunomaduro/collision:
+ *
  * @link https://raw.githubusercontent.com/nunomaduro/collision/stable/src/ConsoleColor.php
  */
 class ConsoleColor
 {
     const FOREGROUND = 38;
+
     const BACKGROUND = 48;
 
     const COLOR256_REGEXP = '~^(bg_)?color_(\d{1,3})$~';
@@ -80,10 +82,7 @@ class ConsoleColor
     }
 
     /**
-     * @param string|array $style
-     * @param string       $text
-     *
-     * @return string
+     * @param  string|array  $style
      *
      * @throws InvalidStyleException
      * @throws \InvalidArgumentException
@@ -122,7 +121,7 @@ class ConsoleColor
             return $text;
         }
 
-        return $this->escSequence(implode(';', $sequences)) . $text . $this->escSequence(self::RESET_STYLE);
+        return $this->escSequence(implode(';', $sequences)).$text.$this->escSequence(self::RESET_STYLE);
     }
 
     public function setForceStyle(bool $forceStyle): void
@@ -144,7 +143,7 @@ class ConsoleColor
     }
 
     /**
-     * @param array|string $styles
+     * @param  array|string  $styles
      */
     public function addTheme(string $name, $styles): void
     {
@@ -157,7 +156,7 @@ class ConsoleColor
 
         foreach ($styles as $style) {
             if (! $this->isValidStyle($style)) {
-                throw new \Exception($style); //InvalidStyleException
+                throw new \Exception($style); // InvalidStyleException
             }
         }
 
@@ -233,18 +232,13 @@ class ConsoleColor
         return "$type;5;$value";
     }
 
-    /**
-     * @param string $style
-     *
-     * @return bool
-     */
     protected function isValidStyle(string $style): bool
     {
         return array_key_exists($style, self::STYLES) || preg_match(self::COLOR256_REGEXP, $style);
     }
 
     /**
-     * @param string|int $value
+     * @param  string|int  $value
      */
     protected function escSequence($value): string
     {

--- a/src/Printers/Highlighters/SyntaxHighlighterV2.php
+++ b/src/Printers/Highlighters/SyntaxHighlighterV2.php
@@ -8,24 +8,37 @@ use Spatie\XRay\Support\Str;
 
 /**
  * Original code taken from nunomaduro/collision
+ *
  * @link https://github.com/nunomaduro/collision/blob/stable/src/Highlighter.php
  */
 class SyntaxHighlighterV2
 {
     public const TOKEN_COMMENT = 'token_comment';
+
     public const TOKEN_DEFAULT = 'token_default';
+
     public const TOKEN_HTML = 'token_html';
+
     public const TOKEN_KEYWORD = 'token_keyword';
+
     public const TOKEN_STRING = 'token_string';
+
     public const TOKEN_VARIABLE = 'token_variable';
+
     public const ACTUAL_LINE_MARK = 'actual_line_mark';
+
     public const LINE_NUMBER = 'line_number';
 
-    protected const ARROW_SYMBOL_UTF8 = ' ❱❱';//➜';
+    protected const ARROW_SYMBOL_UTF8 = ' ❱❱'; // ➜';
+
     protected const DELIMITER_UTF8 = '▕ ';
+
     protected const LINE_NUMBER_DIVIDER = 'line_divider';
+
     protected const MARKED_LINE_NUMBER = 'marked_line';
+
     protected const WIDTH = 4;
+
     protected const TARGET_LINE = 'target_line';
 
     /**
@@ -45,7 +58,7 @@ class SyntaxHighlighterV2
         self::LINE_NUMBER => ['dark_gray'],
         self::MARKED_LINE_NUMBER => ['italic', 'bold'],
         self::LINE_NUMBER_DIVIDER => ['dark_gray'],
-        self::TARGET_LINE => ['bold', 'italic'], //'bg_color_25'],
+        self::TARGET_LINE => ['bold', 'italic'], // 'bg_color_25'],
     ];
 
     /** @var ConsoleColor */
@@ -81,7 +94,7 @@ class SyntaxHighlighterV2
 
     public function __construct(?ConsoleColor $color = null)
     {
-        $this->color = $color ?? new ConsoleColor();
+        $this->color = $color ?? new ConsoleColor;
 
         foreach (self::DEFAULT_THEME as $name => $styles) {
             if (! $this->color->hasTheme($name)) {
@@ -133,7 +146,7 @@ class SyntaxHighlighterV2
     protected function tokenize(string $source): array
     {
         if (! $this->hasOpenTag) {
-            $source = "<?"."php {$source}";
+            $source = '<?'."php {$source}";
         }
 
         $tokens = token_get_all($source);
@@ -148,7 +161,6 @@ class SyntaxHighlighterV2
                 switch ($token[0]) {
                     case T_WHITESPACE:
                         break;
-
 
                     case T_OPEN_TAG:
                         // mark the token as a keyword if it wasn't added automatically for tokenization
@@ -296,7 +308,7 @@ class SyntaxHighlighterV2
         $lineStrlen = strlen((string) (array_key_last($lines) + 1));
         $lineStrlen = $lineStrlen < self::WIDTH ? self::WIDTH : $lineStrlen;
         $snippet = '';
-        $mark = str_pad($this->arrow . ' ', 4, ' ', STR_PAD_LEFT);
+        $mark = str_pad($this->arrow.' ', 4, ' ', STR_PAD_LEFT);
 
         foreach ($lines as $lineNum => $line) {
             $coloredLineNumber = $this->coloredLineNumber(self::LINE_NUMBER, $lineNum, $lineStrlen);
@@ -316,7 +328,7 @@ class SyntaxHighlighterV2
 
             $snippet .= $coloredLineNumber;
             $snippet .= $this->color->apply(self::LINE_NUMBER_DIVIDER, $this->delimiter);
-            $snippet .= $line . PHP_EOL;
+            $snippet .= $line.PHP_EOL;
         }
 
         return $snippet;
@@ -324,6 +336,6 @@ class SyntaxHighlighterV2
 
     protected function coloredLineNumber(string $style, int $lineNum, int $lineStrlen): string
     {
-        return $this->color->apply($style, str_pad((string)$lineNum, $lineStrlen, ' ', STR_PAD_LEFT));
+        return $this->color->apply($style, str_pad((string) $lineNum, $lineStrlen, ' ', STR_PAD_LEFT));
     }
 }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -7,9 +7,7 @@ class Str
     /**
      * Determine if a given string starts with a given substring.
      *
-     * @param string $haystack
-     * @param string|string[] $needles
-     * @return bool
+     * @param  string|string[]  $needles
      */
     public static function startsWith(string $haystack, array|string $needles): bool
     {
@@ -24,10 +22,6 @@ class Str
 
     /**
      * Return the remainder of a string after the last occurrence of a given value.
-     *
-     * @param  string  $subject
-     * @param  string  $search
-     * @return string
      */
     public static function afterLast(string $subject, string $search): string
     {

--- a/tests/CodeScannerTest.php
+++ b/tests/CodeScannerTest.php
@@ -17,9 +17,8 @@ class CodeScannerTest extends TestCase
     /** @test */
     public function it_scans_a_file()
     {
-        $file = new File(__DIR__ . '/fixtures/fixture1.php');
+        $file = new File(__DIR__.'/fixtures/fixture1.php');
         $scanner = new CodeScanner($this->getConfig(), $file->getRealPath());
-
 
         $results = $scanner->scanFile($file->getRealPath());
 
@@ -33,7 +32,7 @@ class CodeScannerTest extends TestCase
     /** @test */
     public function it_returns_an_error_for_parsing_errors()
     {
-        $file = new File(__DIR__ . '/fixtures/fixture2.php');
+        $file = new File(__DIR__.'/fixtures/fixture2.php');
         $scanner = new CodeScanner($this->getConfig(), $file->getRealPath());
 
         $results = $scanner->scanFile($file->getRealPath());

--- a/tests/Commands/ScanCommandTest.php
+++ b/tests/Commands/ScanCommandTest.php
@@ -31,7 +31,7 @@ class ScanCommandTest extends TestCase
         parent::setUp();
 
         $this->command = new ScanCommand('scan');
-        $this->output = new FakeOutput();
+        $this->output = new FakeOutput;
     }
 
     protected function createInput(array $input): ArrayInput
@@ -50,10 +50,10 @@ class ScanCommandTest extends TestCase
     /** @test */
     public function it_executes_the_command_with_a_valid_filename()
     {
-        $input = $this->createInput(['path' => __DIR__ . '/../fixtures/fixture1.php', '--no-progress' => true, '--snippets' => true]);
+        $input = $this->createInput(['path' => __DIR__.'/../fixtures/fixture1.php', '--no-progress' => true, '--snippets' => true]);
 
         $this->command->printer = new FakeConsoleResultsPrinter($this->createConfigurationFromInput($input));
-        $this->command->printer->consoleColor = new FakeConsoleColor();
+        $this->command->printer->consoleColor = new FakeConsoleColor;
 
         $this->command->execute($input, $this->output);
 
@@ -63,11 +63,11 @@ class ScanCommandTest extends TestCase
     /** @test */
     public function it_executes_the_command_with_a_valid_path()
     {
-        $path = [__DIR__ . '/../fixtures'];
+        $path = [__DIR__.'/../fixtures'];
         $input = $this->createInput(['path' => $path, '--no-progress' => true, '--snippets' => true]);
 
         $this->command->printer = new FakeConsoleResultsPrinter($this->createConfigurationFromInput($input));
-        $this->command->printer->consoleColor = new FakeConsoleColor();
+        $this->command->printer->consoleColor = new FakeConsoleColor;
 
         $this->command->execute($input, $this->output);
 
@@ -77,12 +77,11 @@ class ScanCommandTest extends TestCase
     /** @test */
     public function it_executes_the_command_with_a_valid_path_and_ignores_the_specified_files()
     {
-        $path = [__DIR__ . '/../fixtures'];
+        $path = [__DIR__.'/../fixtures'];
         $input = $this->createInput(['path' => $path, '--no-progress' => true, '--snippets' => false, '--ignore' => ['fixture*.php']]);
 
         $this->command->printer = new FakeConsoleResultsPrinter($this->createConfigurationFromInput($input));
-        $this->command->printer->consoleColor = new FakeConsoleColor();
-
+        $this->command->printer->consoleColor = new FakeConsoleColor;
 
         $this->command->execute($input, $this->output);
 
@@ -97,8 +96,7 @@ class ScanCommandTest extends TestCase
         $input = $this->createInput(['path' => $path, '--no-progress' => true, '--snippets' => false, '--verbose' => true]);
 
         $this->command->printer = new FakeConsoleResultsPrinter($this->createConfigurationFromInput($input));
-        $this->command->printer->consoleColor = new FakeConsoleColor();
-
+        $this->command->printer->consoleColor = new FakeConsoleColor;
 
         $this->command->execute($input, $this->output);
 
@@ -108,9 +106,9 @@ class ScanCommandTest extends TestCase
     /** @test */
     public function it_executes_and_has_no_scan_results_and_returns_a_success_exit_code()
     {
-        $this->command->printer = new FakeConsoleResultsPrinter($this->createConfiguration(__DIR__ . '/../fixtures/fixture1.php'));
+        $this->command->printer = new FakeConsoleResultsPrinter($this->createConfiguration(__DIR__.'/../fixtures/fixture1.php'));
 
-        $input = $this->createInput(['path' => __DIR__ . '/../fixtures/fixture3.php', '--no-progress' => true]);
+        $input = $this->createInput(['path' => __DIR__.'/../fixtures/fixture3.php', '--no-progress' => true]);
 
         $result = $this->command->execute($input, $this->output);
 
@@ -120,8 +118,8 @@ class ScanCommandTest extends TestCase
     /** @test */
     public function it_executes_the_command_with_a_valid_filename_and_displays_progress()
     {
-        $input = $this->createInput(['path' => __DIR__ . '/../fixtures/fixture1.php']);
-        $this->command->printer = new FakeConsoleResultsPrinter($this->createConfiguration(__DIR__ . '/../fixtures/fixture1.php'));
+        $input = $this->createInput(['path' => __DIR__.'/../fixtures/fixture1.php']);
+        $this->command->printer = new FakeConsoleResultsPrinter($this->createConfiguration(__DIR__.'/../fixtures/fixture1.php'));
 
         $this->command->execute($input, $this->output);
 

--- a/tests/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Configuration/ConfigurationFactoryTest.php
@@ -28,7 +28,7 @@ class ConfigurationFactoryTest extends TestCase
         $path = [realpath(__DIR__.'/../fixtures/fixture1.php')];
         $input = $this->createInput(['path' => $path, '--no-progress' => true, '--snippets' => true]);
 
-        $config = ConfigurationFactory::create($input, __DIR__ . '/../data');
+        $config = ConfigurationFactory::create($input, __DIR__.'/../data');
 
         $this->assertTrue($config->showSnippets);
         $this->assertTrue($config->hideProgress);
@@ -41,7 +41,7 @@ class ConfigurationFactoryTest extends TestCase
         $filename = [realpath(__DIR__.'/../fixtures/missing.php')];
 
         $input = $this->createInput(['path' => $filename, '--no-progress' => true]);
-        $config = ConfigurationFactory::create($input, __DIR__ . '/../data');
+        $config = ConfigurationFactory::create($input, __DIR__.'/../data');
 
         $this->expectException(\InvalidArgumentException::class);
 
@@ -54,7 +54,7 @@ class ConfigurationFactoryTest extends TestCase
         $filename = [realpath(__DIR__.'/../fixtures/fixture1.php')];
 
         $input = $this->createInput(['path' => $filename, '--no-progress' => true]);
-        $config = ConfigurationFactory::create($input, __DIR__ . '/../data');
+        $config = ConfigurationFactory::create($input, __DIR__.'/../data');
         $hasException = false;
 
         try {

--- a/tests/Printers/ConsoleResultPrinterTest.php
+++ b/tests/Printers/ConsoleResultPrinterTest.php
@@ -26,7 +26,7 @@ class ConsoleResultPrinterTest extends TestCase
     {
         $file = new File(__DIR__.'/../fixtures/fixture1.php');
         $location = new GenericCodeLocation(3, 3);
-        $snippet = (new CodeSnippet())
+        $snippet = (new CodeSnippet)
             ->surroundingLine(4)
             ->snippetLineCount(3)
             ->fromFile($file->getRealPath());
@@ -35,12 +35,12 @@ class ConsoleResultPrinterTest extends TestCase
 
         $result = new SearchResult($node, $location, $snippet, basename($file->filename));
         $result->file()->filename = basename($file->filename);
-        $output = new FakeOutput();
+        $output = new FakeOutput;
 
         $options = ['path' => $file->getRealPath(), '--snippets' => true];
         $printer = new ConsoleResultPrinter($this->createConfiguration(__DIR__, null, $options));
 
-        $printer->consoleColor = new FakeConsoleColor();
+        $printer->consoleColor = new FakeConsoleColor;
 
         $printer->print($output, $result);
 

--- a/tests/Printers/ConsoleResultsPrinterTest.php
+++ b/tests/Printers/ConsoleResultsPrinterTest.php
@@ -18,11 +18,11 @@ class ConsoleResultsPrinterTest extends TestCase
     /** @test */
     public function it_prints_a_summary_with_a_table()
     {
-        $path = __DIR__ . '/../fixtures/fixture1.php';
+        $path = __DIR__.'/../fixtures/fixture1.php';
         $config = $this->createConfiguration($path, null, ['path' => $path, '--summary' => true]);
-        $output = new FakeOutput();
+        $output = new FakeOutput;
         $printer = new ConsoleResultsPrinter($output, $config);
-        $printer->consoleColor = new FakeConsoleColor();
+        $printer->consoleColor = new FakeConsoleColor;
         $scanner = new CodeScanner($config, $path);
 
         $results = $scanner->scan();
@@ -34,11 +34,11 @@ class ConsoleResultsPrinterTest extends TestCase
     /** @test */
     public function it_prints_a_summary_without_a_table()
     {
-        $path = __DIR__ . '/../fixtures/fixture1.php';
+        $path = __DIR__.'/../fixtures/fixture1.php';
         $config = $this->createConfiguration([$path], null, ['path' => $path]);
-        $output = new FakeOutput();
+        $output = new FakeOutput;
         $printer = new ConsoleResultsPrinter($output, $config);
-        $printer->consoleColor = new FakeConsoleColor();
+        $printer->consoleColor = new FakeConsoleColor;
         $scanner = new CodeScanner($config, $path);
 
         $results = $scanner->scan();
@@ -50,11 +50,11 @@ class ConsoleResultsPrinterTest extends TestCase
     /** @test */
     public function it_prints_a_summary_with_github_annotation()
     {
-        $path = __DIR__ . '/../fixtures/fixture1.php';
+        $path = __DIR__.'/../fixtures/fixture1.php';
         $config = $this->createConfiguration([$path], null, ['path' => $path, '--github' => true]);
-        $output = new FakeOutput();
+        $output = new FakeOutput;
         $printer = new ConsoleResultsPrinter($output, $config);
-        $printer->consoleColor = new FakeConsoleColor();
+        $printer->consoleColor = new FakeConsoleColor;
         $scanner = new CodeScanner($config, $path);
 
         $results = $scanner->scan();

--- a/tests/Printers/Highlighters/ConsoleColorTest.php
+++ b/tests/Printers/Highlighters/ConsoleColorTest.php
@@ -13,7 +13,7 @@ class ConsoleColorTest extends TestCase
     /** @test */
     public function it_gets_the_defined_themes()
     {
-        $color = new ConsoleColor();
+        $color = new ConsoleColor;
         $color->setThemes([]);
 
         $this->assertEquals([], $color->getThemes());
@@ -23,7 +23,7 @@ class ConsoleColorTest extends TestCase
     public function it_sets_the_defined_themes()
     {
         $themes = ['token_string' => ['color_70']];
-        $color = new ConsoleColor();
+        $color = new ConsoleColor;
         $color->setThemes($themes);
 
         $this->assertEquals($themes, $color->getThemes());
@@ -33,14 +33,14 @@ class ConsoleColorTest extends TestCase
     public function it_throws_an_error_when_adding_an_invalid_theme()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $color = new ConsoleColor();
+        $color = new ConsoleColor;
         $color->addTheme('test', 123);
     }
 
     /** @test */
     public function it_removes_a_theme()
     {
-        $color = new ConsoleColor();
+        $color = new ConsoleColor;
         $color->addTheme('test', ['color_70']);
 
         $this->assertEquals(['test' => ['color_70']], $color->getThemes());
@@ -53,7 +53,7 @@ class ConsoleColorTest extends TestCase
     /** @test */
     public function it_gets_possible_styles()
     {
-        $color = new ConsoleColor();
+        $color = new ConsoleColor;
 
         $this->assertMatchesSnapshot($color->getPossibleStyles());
     }
@@ -62,14 +62,14 @@ class ConsoleColorTest extends TestCase
     public function it_throws_an_exception_when_adding_a_theme_with_an_invalid_style()
     {
         $this->expectException(\Exception::class);
-        $color = new ConsoleColor();
+        $color = new ConsoleColor;
         $color->addTheme('test', ['color_AAAAA']);
     }
 
     /** @test */
     public function it_sets_and_gets_the_forced_style_property()
     {
-        $color = new ConsoleColor();
+        $color = new ConsoleColor;
 
         $color->setForceStyle(true);
         $this->assertTrue($color->isStyleForced());

--- a/tests/Printers/Highlighters/SyntaxHighlighterV2Test.php
+++ b/tests/Printers/Highlighters/SyntaxHighlighterV2Test.php
@@ -16,12 +16,12 @@ class SyntaxHighlighterV2Test extends TestCase
     /** @test */
     public function it_highlights_snippets()
     {
-        $highlighter = new SyntaxHighlighterV2(new FakeConsoleColor());
+        $highlighter = new SyntaxHighlighterV2(new FakeConsoleColor);
 
-        $snippet = (new CodeSnippet())
+        $snippet = (new CodeSnippet)
             ->surroundingLine(3)
             ->snippetLineCount(5)
-            ->fromFile(__DIR__ . '/../../fixtures/fixture1.php');
+            ->fromFile(__DIR__.'/../../fixtures/fixture1.php');
 
         $this->assertMatchesSnapshot($highlighter->highlightSnippet($snippet, Bounds::create(3, 3)));
     }

--- a/tests/TestClasses/FakeConsoleResultPrinter.php
+++ b/tests/TestClasses/FakeConsoleResultPrinter.php
@@ -9,7 +9,7 @@ class FakeConsoleResultPrinter extends ConsoleResultPrinter
 {
     public function print($output, SearchResult $result): void
     {
-        $result->file()->filename = str_replace(realpath(__DIR__ . '/../..'), '', $result->file()->getRealPath());
+        $result->file()->filename = str_replace(realpath(__DIR__.'/../..'), '', $result->file()->getRealPath());
 
         parent::print($output, $result);
     }

--- a/tests/TestClasses/FakeConsoleResultsPrinter.php
+++ b/tests/TestClasses/FakeConsoleResultsPrinter.php
@@ -12,6 +12,6 @@ class FakeConsoleResultsPrinter extends ConsoleResultsPrinter
         $this->config = $config;
 
         $this->printer = new FakeConsoleResultPrinter($config);
-        $this->printer->consoleColor = new FakeConsoleColor();
+        $this->printer->consoleColor = new FakeConsoleColor;
     }
 }

--- a/tests/TestClasses/FakeOutput.php
+++ b/tests/TestClasses/FakeOutput.php
@@ -13,7 +13,7 @@ class FakeOutput implements OutputInterface
 
     public function __construct()
     {
-        $this->formatter = new FakeFormatter();
+        $this->formatter = new FakeFormatter;
     }
 
     public function getFormatter(): OutputFormatterInterface
@@ -82,9 +82,9 @@ class FakeOutput implements OutputInterface
             $this->writtenData[] = '';
         }
 
-        $this->writtenData[count($this->writtenData) - 1] .= $this->stripAnsi($messages) . ($newline ? PHP_EOL : '');
+        $this->writtenData[count($this->writtenData) - 1] .= $this->stripAnsi($messages).($newline ? PHP_EOL : '');
 
-        //$this->writtenData[] = $this->stripAnsi($messages);
+        // $this->writtenData[] = $this->stripAnsi($messages);
     }
 
     public function writeln($messages, int $options = 0): void

--- a/tests/Traits/CreatesTestConfiguration.php
+++ b/tests/Traits/CreatesTestConfiguration.php
@@ -32,7 +32,7 @@ trait CreatesTestConfiguration
             $path = [$path];
         }
 
-        $configPath = $configPath ?? __DIR__ . '/../data';
+        $configPath = $configPath ?? __DIR__.'/../data';
         $options = $options ?? ['path' => $path, '--no-progress' => true, '--snippets' => false];
 
         $input = $this->createInput($options);
@@ -42,7 +42,7 @@ trait CreatesTestConfiguration
 
     protected function createConfigurationFromInput(InputInterface $input, ?string $configPath = null): Configuration
     {
-        $configPath = $configPath ?? __DIR__ . '/../data';
+        $configPath = $configPath ?? __DIR__.'/../data';
 
         return ConfigurationFactory::create($input, $configPath);
     }


### PR DESCRIPTION
## Summary
- Apply Laravel Pint code style fixes across the codebase
- Add `pint.json` to exclude `tests/fixtures` from formatting (these fixtures contain intentional formatting for snapshot tests)

## Test plan
- [x] `pint --test` passes clean
- [x] All 25 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)